### PR TITLE
Client's default api_entrypoint is missing a slash.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 Python bindings to the [OnaData][1] API
 =====================
-This repo contains the sources for the OnaData python client library. 
+This repo contains the sources for the OnaData python client library.
 You can read more about OnaData [here][1]
 
 #### Installation
 
 ```sh
-pip install git+https://github.com/onaio/onaie.git
+pip install git+https://github.com/onaio/onapie.git
 ```
 
 OR as a [pip editable](http://pip.readthedocs.org/en/latest/reference/pip_install.html#editable-installs) if you'd like to develop this in parallel with your project:-  

--- a/onapie/client.py
+++ b/onapie/client.py
@@ -14,7 +14,7 @@ class Client(object):
         username = kwargs.get('username', None)
         password = kwargs.get('password', None)
         self.api_token = kwargs.get('api_token', None)
-        self.api_entrypoint = kwargs.get('api_entrypoint', '/api/v1')
+        self.api_entrypoint = kwargs.get('api_entrypoint', '/api/v1/')
         auth_path = kwargs.get('auth_path', '/user')
         self.auth_path = '{}{}'.format(self.api_entrypoint, auth_path)
 


### PR DESCRIPTION
`/api/v1` results in HTML being returned, `/api/v1/` returns the JSON. The default setup in the client now results in a `ValueError` exception being raised when the HTML is parsed as JSON.