### PR TITLE
Remove duplicated python 3 urlparse import

### DIFF
--- a/onapie/client.py
+++ b/onapie/client.py
@@ -4,14 +4,13 @@ from onapie.xlsforms import XlsFormsManager
 from onapie.data import DataManager
 from onapie.stats import StatsManager
 from onapie.utils import ConnectionSingleton
-from urllib.parse import urlparse
 from requests.auth import HTTPDigestAuth
 
 
 try:
     from urllib.parse import urlparse  # NOQA
 except ImportError:
-    from urlparse import urlparse # NOQA
+    from urlparse import urlparse  # NOQA
 
 
 class Client(object):


### PR DESCRIPTION
The previous fix for urlparse references left this line which is breaking in python 2.7